### PR TITLE
fix: player bar transcription bug + mobile scroll performance

### DIFF
--- a/src/app/episodes/[slug]/transcription/TranscriptionPage.tsx
+++ b/src/app/episodes/[slug]/transcription/TranscriptionPage.tsx
@@ -247,21 +247,31 @@ export default function TranscriptionPage({
     return markers;
   }, [contentSections]);
 
-  // Push speaker segments to the player store
-  useEffect(() => {
+  // Build speaker segments once
+  const speakerSegments = useMemo(() => {
     const hasSpeakers = entries.some((e) => e.speaker_id);
-    if (!hasSpeakers) return;
+    if (!hasSpeakers) return null;
 
-    const segments: SpeakerSegment[] = entries
+    return entries
       .filter((e) => e.speaker_id)
       .map((e) => ({
         start: srtTimeToSeconds(e.startTime),
         end: srtTimeToSeconds(e.endTime),
         speakerId: e.speaker_id!,
       }));
-
-    usePlayerStore.getState().setSpeakerSegments(segments);
   }, [entries]);
+
+  // Push speaker segments to the player store only when this episode is playing
+  const playerEpisodeId = usePlayerStore(
+    useShallow((state) => state.episode?.id)
+  );
+
+  useEffect(() => {
+    if (!speakerSegments) return;
+    if (playerEpisodeId !== episode.id) return;
+
+    usePlayerStore.getState().setSpeakerSegments(speakerSegments);
+  }, [speakerSegments, playerEpisodeId, episode.id]);
 
   // Focus search input when opened
   useEffect(() => {

--- a/src/components/Cards/EpisodeCard/EpisodeCard.module.css
+++ b/src/components/Cards/EpisodeCard/EpisodeCard.module.css
@@ -87,7 +87,6 @@
   height: 100% !important;
   object-fit: cover;
   color: transparent;
-  filter: brightness(0.9);
   transition: filter 0.3s ease, transform 0.3s ease;
 }
 
@@ -321,6 +320,20 @@
     max-width: 220px;
     min-width: 90px;
     border-radius: 10px;
+    transition: none;
+  }
+
+  .cardArticle:hover {
+    transform: none;
+  }
+
+  .cardArticle:hover .cardImage {
+    filter: none;
+    transform: none;
+  }
+
+  .cardImage {
+    transition: none;
   }
 
   .cardTitle {

--- a/src/components/ChocolateBox/ChocolateBox.module.css
+++ b/src/components/ChocolateBox/ChocolateBox.module.css
@@ -471,6 +471,10 @@
 }
 
 @media (max-width: 768px) {
+  .randomEpisode {
+    animation: none;
+  }
+
   .coffret {
     padding: 6px;
     transform-style: flat;

--- a/src/components/Sections/HeroSection/PodcastBackground.module.css
+++ b/src/components/Sections/HeroSection/PodcastBackground.module.css
@@ -39,7 +39,7 @@
   border-radius: 12px;
   overflow: hidden;
   box-shadow: var(--shadow-medium);
-  transition: all var(--transition-normal);
+  transition: opacity var(--transition-normal);
   flex-shrink: 0;
   perspective: 800px;
 }
@@ -101,7 +101,6 @@
   height: 100%;
   object-fit: cover;
   border-radius: 12px;
-  transition: all var(--transition-normal);
 }
 
 .imagePlaceholder {
@@ -122,6 +121,22 @@
   }
   100% {
     opacity: 0.4;
+  }
+}
+
+@media (max-width: 768px) {
+  .heroCoverArtsDiv {
+    perspective: none;
+    box-shadow: none;
+    transition: none;
+  }
+
+  .heroCoverArtsDiv:hover {
+    opacity: unset;
+    filter: none;
+    transform: none;
+    box-shadow: none;
+    z-index: auto;
   }
 }
 

--- a/src/components/Sections/HeroSection/PodcastBackgroundAnimation.tsx
+++ b/src/components/Sections/HeroSection/PodcastBackgroundAnimation.tsx
@@ -5,7 +5,8 @@ import { IMAGE_CONFIG } from "@/helpers/imageConfig";
 import styles from "./PodcastBackground.module.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const GRID_SIZE = 100;
+const GRID_SIZE_DESKTOP = 100;
+const GRID_SIZE_MOBILE = 50;
 const SWAP_INTERVAL = 2000;
 const SWAP_COUNT = 1;
 const FLIP_DURATION = 1400;
@@ -19,9 +20,12 @@ export function PodcastBackgroundAnimation({
   repeatedImages,
   fallbackImages,
 }: PodcastBackgroundAnimationProps) {
+  const [isMobile, setIsMobile] = useState(false);
+  const gridSize = isMobile ? GRID_SIZE_MOBILE : GRID_SIZE_DESKTOP;
+
   const [isTransitioning, setIsTransitioning] = useState(true);
   const [currentImages, setCurrentImages] = useState<string[]>(() =>
-    Array.from({ length: GRID_SIZE }, (_, i) =>
+    Array.from({ length: GRID_SIZE_DESKTOP }, (_, i) =>
       repeatedImages.length > 0
         ? repeatedImages[i % repeatedImages.length]
         : fallbackImages[i % fallbackImages.length]
@@ -33,7 +37,12 @@ export function PodcastBackgroundAnimation({
   const pendingSwaps = useRef<Map<number, string>>(new Map());
 
   useEffect(() => {
+    const mq = window.matchMedia("(max-width: 768px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
     setIsTransitioning(false);
+    return () => mq.removeEventListener("change", handler);
   }, []);
 
   const pickNewImage = useCallback(
@@ -52,12 +61,12 @@ export function PodcastBackgroundAnimation({
   );
 
   useEffect(() => {
-    if (isTransitioning || repeatedImages.length < 2) return;
+    if (isTransitioning || repeatedImages.length < 2 || isMobile) return;
 
     const interval = setInterval(() => {
       const indices = new Set<number>();
       while (indices.size < SWAP_COUNT) {
-        indices.add(Math.floor(Math.random() * GRID_SIZE));
+        indices.add(Math.floor(Math.random() * gridSize));
       }
 
       const swaps = new Map<number, string>();
@@ -86,7 +95,7 @@ export function PodcastBackgroundAnimation({
     }, SWAP_INTERVAL);
 
     return () => clearInterval(interval);
-  }, [isTransitioning, repeatedImages, pickNewImage]);
+  }, [isTransitioning, repeatedImages, pickNewImage, isMobile, gridSize]);
 
   return (
     <div className={styles.headerScroll}>
@@ -95,7 +104,7 @@ export function PodcastBackgroundAnimation({
           isTransitioning ? styles.loading : styles.loaded
         }`}
       >
-        {currentImages.map((image, index) => (
+        {currentImages.slice(0, gridSize).map((image, index) => (
           <div
             key={index}
             className={`${styles.heroCoverArtsDiv} ${

--- a/src/lib/store/player.ts
+++ b/src/lib/store/player.ts
@@ -56,7 +56,9 @@ export const usePlayerStore = create(
       ...defaultInitState,
       setIsPlaying: (isPlaying: boolean) => set({ isPlaying }),
       setEpisode: (episode: EpisodeInfo) => {
-        set({ episode });
+        const current = get().episode;
+        const changed = current?.id !== episode.id;
+        set({ episode, ...(changed ? { speakerSegments: null } : {}) });
         const queueStore = useQueueStore.getState();
         const queueIndex = queueStore.queue.findIndex(item => item.id === episode.id);
         if (queueIndex !== -1) {
@@ -64,10 +66,7 @@ export const usePlayerStore = create(
         }
       },
       setRandomEpisode: (episode: EpisodeInfo) => {
-        set({ isPlaying: false });
-        set({ currentPlayTime: 0 });
-        set({ episode });
-        set({ launchPlay: true });
+        set({ isPlaying: false, currentPlayTime: 0, episode, launchPlay: true, speakerSegments: null });
         set({ isPlaying: true });
       },
       setLaunchPlay: (launchPlay: boolean) => set({ launchPlay }),
@@ -80,7 +79,7 @@ export const usePlayerStore = create(
         const queueStore = useQueueStore.getState();
         const nextEpisode = queueStore.getNextEpisode();
         if (nextEpisode) {
-          set({ episode: nextEpisode, isPlaying: true });
+          set({ episode: nextEpisode, isPlaying: true, speakerSegments: null });
           queueStore.setCurrentIndex(queueStore.currentIndex + 1);
         }
       },
@@ -88,7 +87,7 @@ export const usePlayerStore = create(
         const queueStore = useQueueStore.getState();
         const previousEpisode = queueStore.getPreviousEpisode();
         if (previousEpisode) {
-          set({ episode: previousEpisode, isPlaying: true });
+          set({ episode: previousEpisode, isPlaying: true, speakerSegments: null });
           queueStore.setCurrentIndex(queueStore.currentIndex - 1);
         }
       },


### PR DESCRIPTION
Fix speaker segments being applied to wrong podcast in AudioVisualizer by only pushing segments when the playing episode matches the transcription page, and clearing segments on episode change.

Optimize mobile homepage scroll by disabling expensive CSS animations (pulse-glow, transition:all, perspective, box-shadow) and reducing the background image grid from 100 to 50 elements on mobile.